### PR TITLE
Fix sendmail warning on debian based systems

### DIFF
--- a/templates/me.j2
+++ b/templates/me.j2
@@ -1,1 +1,1 @@
-{{ nullmailer_me }}
+{% if ansible_os_family != "Debian" %}{{ nullmailer_me }}{% endif %}


### PR DESCRIPTION
Leave `/etc/nullmailer/me` emtpty on Debian based systems, otherwise sendmail produces the following warning:

`Warning: On Debian systems, nullmailer's 'me' is disregarded; please use '/etc/mailname' instead.`

Nullmailer use of /etc/mailname is [documented in the Debian Wiki](https://wiki.debian.org/EtcMailName#nullmailer).